### PR TITLE
Feature/optimize ai agent

### DIFF
--- a/Backend/app/ai_agent/main.py
+++ b/Backend/app/ai_agent/main.py
@@ -74,6 +74,53 @@ def default_serializer(obj):
         return obj.isoformat()
     return str(obj)
 
+
+def build_llm_payload(retrieved: dict, max_groups: int = 50, sample_docs: int = 3) -> dict:
+    payload = {"chosen_source": retrieved.get("chosen_source"), "summary": retrieved.get("summary")}
+    llm = {}
+
+    # Mongo aggregate
+    mongo = retrieved.get("mongo", {})
+    agg = {}
+    for k, v in mongo.items():
+        if isinstance(v, dict) and v.get("operation") == "aggregate":
+            rows = (v.get("results") or [])[:max_groups]  # top-N grupos
+            agg[k] = {
+                "rows": rows,
+                "showing": v.get("showing"),
+                "total_found": v.get("total_found"),
+                "page": v.get("page")
+            }
+    if agg: llm["mongo_aggregate"] = agg
+
+    # Mongo find
+    finds = {}
+    for k, v in mongo.items():
+        if isinstance(v, dict) and v.get("operation") == "find":
+            docs = (v.get("documents") or [])[:sample_docs]
+            finds[k] = {"count": v.get("count"), "sample": docs, "page": v.get("page")}
+    if finds: llm["mongo_find"] = finds
+
+    # Chroma
+    chroma = retrieved.get("chroma") or {}
+    chroma_out = {}
+    for cname, data in chroma.items():
+        if isinstance(data, dict) and data.get("documents"):
+            short = []
+            for d in data["documents"][:10]:
+                short.append({
+                    "metadata": d.get("metadata", {}),
+                    "similarity": round(d.get("similarity", 0), 4),
+                    "collection": d.get("collection"),
+                    "preview": (d.get("content") or "")[:200]
+                })
+            chroma_out[cname] = {"count": data.get("count"), "docs": short}
+    if chroma_out: llm["chroma"] = chroma_out
+
+    payload["llm_payload"] = llm
+    return payload
+
+
 @router.post("/ask")
 def ask(
     payload: QueryIn,
@@ -84,24 +131,31 @@ def ask(
     history = conversation_memory.get(user_id, deque(maxlen=MAX_CONTEXT))
     user_q = payload.question
 
+    # 1. Generar queries y ejecutar
     queries = query_generator(user_q)
     retrieved = execute_queries(queries)
 
-    system = "Eres un asistente que responde claro y profesional, manteniendo un estilo corporativo."
+    # 2. Construir payload resumido
+    llm_payload = build_llm_payload(retrieved, max_groups=50, sample_docs=3)
+
+    # 3. Preparar prompt para LLM
+    system = "Eres un asistente que responde claro y profesional, estilo corporativo."
     conversation_context = "".join(
         f"Usuario: {q}\nAsistente: {a}\n" for q, a in history
     )
 
     user_content = (
-        f"Contexto de conversación:\n{conversation_context}\n"
-        f"Pregunta actual: {user_q}\n\n"
-        f"Datos recuperados:\n{json.dumps(retrieved, ensure_ascii=False, indent=2, default=default_serializer)}\n\n"
-        "Responde de forma clara y profesional, eliminando saltos de línea innecesarios, "
-        "pero conservando viñetas o listas si la información lo requiere. "
-        "Si no hay datos, indícalo claramente."
-        "cuando se pregunte sobre cantidades haz un conteo y me devuelves en valor numerico si preguntan algo como cuantas, cuantos, cantidad"
+        f"Contexto:\n{conversation_context}\n"
+        f"Pregunta: {user_q}\n\n"
+        "Datos (agregados y resumidos, no inventes nada, reporta exactamente lo que ves):\n"
+        f"{json.dumps(llm_payload, ensure_ascii=False)}\n\n"
+        "Si hay 'mongo_aggregate', entrega KPIs (tendencia, top-N, totales) en viñetas. "
+        "Si hay 'mongo_find', usa solo el 'count' y 'sample' como ejemplos. "
+        "Si hay 'chroma', menciona solo títulos/fechas si existen en metadata. "
+        "No expandas texto largo ni pegues JSON completo en la respuesta."
     )
 
+    # 4. Llamar al LLM
     try:
         resp = openai.chat.completions.create(
             model="gpt-3.5-turbo",
@@ -114,11 +168,12 @@ def ask(
         )
         answer = resp.choices[0].message.content.strip()
 
-        # Limpiar saltos de línea innecesarios
+        # 5. Limpiar saltos de línea innecesarios
         answer_clean = " ".join(
             line.strip() for line in answer.splitlines() if line.strip()
         )
 
+        # 6. Guardar en historial
         history.append((user_q, answer_clean))
         conversation_memory[user_id] = history
 
@@ -127,6 +182,7 @@ def ask(
                 "mode": "debug",
                 "queries": queries,
                 "retrieved": retrieved,
+                "llm_payload": llm_payload,
                 "answer_raw": answer,
                 "answer_clean": answer_clean
             }
@@ -138,4 +194,3 @@ def ask(
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error generando respuesta GPT: {e}")
-

--- a/Backend/app/ai_agent/query_generator_pydantic.py
+++ b/Backend/app/ai_agent/query_generator_pydantic.py
@@ -1,43 +1,49 @@
-#query_generator_pydantic.py
-
 import os
 import json
 import re
 import unicodedata
 from datetime import datetime
-from typing import List, Optional, Dict, Any, Literal
-from pydantic import BaseModel, Field, ValidationError, field_validator
+from typing import Dict, Any, List, Optional, Literal
+from pydantic import BaseModel, Field, ValidationError
 from openai import OpenAI
-from dotenv import load_dotenv
 
-load_dotenv()
+# ========= Config por ENV =========
+def _get_int_env(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, default))
+    except Exception:
+        return default
 
-# ---------- Pydantic Schemas ----------
+# LÍMITES CONFIGURABLES
+MAX_MONGO_LIMIT = _get_int_env("MAX_MONGO_LIMIT", 5000)          # tope duro Mongo
+DEFAULT_MONGO_LIMIT = _get_int_env("DEFAULT_MONGO_LIMIT", 500)   # límite por defecto Mongo
+MAX_CHROMA_LIMIT = _get_int_env("MAX_CHROMA_LIMIT", 2000)        # tope duro Chroma
+DEFAULT_CHROMA_K = _get_int_env("DEFAULT_CHROMA_K", 100)         # n_results por defecto Chroma
 
+# ========= Modelos =========
 class ChromaQuery(BaseModel):
     text: str
-    limit: int = Field(default=5, ge=1, le=50)
-
+    limit: int = Field(default=DEFAULT_CHROMA_K, ge=1, le=MAX_CHROMA_LIMIT)
 
 class MongoQuery(BaseModel):
     database: str
     collection: str
+    operation: str = Field(default="find")  # find | count_documents | aggregate
     filter: Dict[str, Any] = Field(default_factory=dict)
-    sort: Optional[Dict[str, int]] = None  # {"updated_at": -1}
-    limit: int = Field(default=75, ge=1, le=500)
-
+    fields: Optional[Dict[str, int]] = None
+    sort: Optional[Dict[str, int]] = None
+    limit: int = Field(default=DEFAULT_MONGO_LIMIT, ge=1, le=MAX_MONGO_LIMIT)
+    skip: int = Field(default=0, ge=0)  # NUEVO: paginación
+    pipeline: Optional[List[Dict[str, Any]]] = None  # para aggregate
 
 class QueriesBundle(BaseModel):
     source: Literal["mongo", "chroma", "both"]
     mongo: List[MongoQuery] = Field(default_factory=list)
     chroma: Optional[ChromaQuery] = None
 
-
 # ---------- Helpers: schema + whitelists ----------
-
 HERE = os.path.dirname(__file__)
 SCHEMA_PATH = os.path.join(HERE, "schema.json")
-
 
 def load_schema_examples() -> Dict[str, Any]:
     try:
@@ -46,13 +52,7 @@ def load_schema_examples() -> Dict[str, Any]:
     except Exception:
         return {}
 
-
 def allowed_fields_map(schema_json: Dict[str, Any]) -> Dict[tuple, Dict[str, str]]:
-    """
-    Retorna {(db, collection): {campo: tipo}}.
-    Si en schema.json 'fields' es lista de strings → se asume tipo "string".
-    Si es lista de dicts → se extrae el tipo definido.
-    """
     out = {}
     for db_name, collections in schema_json.items():
         if not isinstance(collections, dict):
@@ -60,120 +60,49 @@ def allowed_fields_map(schema_json: Dict[str, Any]) -> Dict[tuple, Dict[str, str
         for col_name, spec in collections.items():
             fields = spec.get("fields") or []
             field_map = {}
-
             if isinstance(fields, list):
                 for f in fields:
                     if isinstance(f, str):
-                        field_map[f] = "string"   # default si no hay tipo
+                        field_map[f] = "string"
                     elif isinstance(f, dict):
-                        # {"campo": "tipo"}
                         for k, v in f.items():
                             field_map[k] = v
             elif isinstance(fields, dict):
-                # si ya viniera como dict completo
                 field_map.update(fields)
-
             out[(db_name, col_name)] = field_map
     return out
 
-
 SAFE_MONGO_OPS = {
     "$eq", "$ne", "$gt", "$gte", "$lt", "$lte",
-    "$in", "$nin", "$regex", "$exists"
+    "$in", "$nin", "$regex", "$exists", "$count"
 }
 
 def normalize_date(value: str) -> str:
-    """
-    Normaliza fechas a formato dd/mm/yyyy que usa tu base.
-    Acepta ISO (2025-06-23), dd-mm-yyyy, etc.
-    """
-    # Intenta distintos formatos comunes
     for fmt in ("%Y-%m-%d", "%d-%m-%Y", "%d/%m/%Y"):
         try:
             dt = datetime.strptime(value, fmt)
             return dt.strftime("%d/%m/%Y")
         except ValueError:
             continue
-    return value  # fallback si no matchea nada
-
-def normalize_text(text: str) -> str:
-    """ Convierte un string a minúsculas y elimina tildes/acentos usando Unicode NFD. """
-    nfkd = unicodedata.normalize("NFD", text)
-    return "".join([c for c in nfkd if not unicodedata.combining(c)]).lower().strip()
-
+    return value
 
 def accent_insensitive_regex(text: str) -> str:
-    """
-    Genera un regex insensible a mayúsculas y acentos/tildes, sin depender
-    de que el input venga acentuado. Incluye variantes comunes de a/e/i/o/u, ñ y ç.
-    Ej: "Medellin" -> (?i)m[eéèêëē]d[eéèêëē]ll[iíìîïī]n
-    """
-    # Map básico de variantes (puedes ampliarlo si necesitas más)
     ACCENT_GROUPS = {
-        "a": "aàáâäãåāăą",
-        "e": "eèéêëēĕėęě",
-        "i": "iìíîïīĭįı",
-        "o": "oòóôöõōŏő",
-        "u": "uùúûüũūŭůűų",
-        "c": "cçćĉċč",
-        "n": "nñńņňŉŋ",
-        "y": "yýÿŷ",
+        "a": "aàáâäãåāăą", "e": "eèéêëēĕėęě",
+        "i": "iìíîïīĭįı", "o": "oòóôöõōŏő",
+        "u": "uùúûüũūŭůűų", "c": "cçćĉċč",
+        "n": "nñńņňŉŋ", "y": "yýÿŷ",
     }
-
     parts = []
     for ch in text:
-        # Ignora marcas combinantes si llegan
         if unicodedata.category(ch) == "Mn":
             continue
-
-        # Base sin diacríticos para decidir el grupo
         base = unicodedata.normalize("NFD", ch)[0].lower()
-
         if base in ACCENT_GROUPS:
-            # Grupo con todas las variantes en minúscula; (?i) hará el resto
-            group = "[" + re.escape(ACCENT_GROUPS[base]) + "]"
-            parts.append(group)
+            parts.append("[" + re.escape(ACCENT_GROUPS[base]) + "]")
         else:
-            # Cualquier otro carácter se escapa tal cual
             parts.append(re.escape(ch))
-
-    pattern = "".join(parts)
-    return f"(?i){pattern}"
-
-
-"""def sanitize_filter(filter_obj: Any, allowed_fields: List[str]) -> Any:
-    if isinstance(filter_obj, dict):
-        clean = {}
-        for k, v in filter_obj.items():
-            if k.startswith("$"):
-                if k in SAFE_MONGO_OPS:
-                    clean[k] = sanitize_filter(v, allowed_fields)
-            else:
-                if k in allowed_fields:
-                    if isinstance(v, str):
-                        regex_pattern = accent_insensitive_regex(v)
-                        clean[k] = {"$regex": regex_pattern, "$options": "i"}  # refuerzo case-insensitive
-                    elif isinstance(v, dict) and "$regex" in v and isinstance(v["$regex"], str):
-                        # Si ya venía un $regex como string, lo transformamos también
-                        regex_pattern = accent_insensitive_regex(v["$regex"])
-                        opts = v.get("$options", "")
-                        if "i" not in opts:
-                            opts += "i"
-                        clean[k] = {"$regex": regex_pattern, "$options": opts}
-                    else:
-                        clean[k] = sanitize_filter(v, allowed_fields)
-        return clean
-    elif isinstance(filter_obj, list):
-        # Mapea strings dentro de listas (p. ej. en $in) a patrones regex si aplica
-        out_list = []
-        for x in filter_obj:
-            if isinstance(x, str):
-                out_list.append({"$regex": accent_insensitive_regex(x), "$options": "i"})
-            else:
-                out_list.append(sanitize_filter(x, allowed_fields))
-        return out_list
-    else:
-        return filter_obj"""
+    return f"(?i){''.join(parts)}"
 
 def sanitize_filter(filter_obj: Any, allowed_fields: Dict[str, str]) -> Any:
     if isinstance(filter_obj, dict):
@@ -185,7 +114,6 @@ def sanitize_filter(filter_obj: Any, allowed_fields: Dict[str, str]) -> Any:
             else:
                 if k in allowed_fields:
                     ftype = allowed_fields[k]
-
                     if isinstance(v, str):
                         if ftype == "date":
                             clean[k] = {"$eq": normalize_date(v)}
@@ -195,11 +123,8 @@ def sanitize_filter(filter_obj: Any, allowed_fields: Dict[str, str]) -> Any:
                             except Exception:
                                 clean[k] = {"$eq": v}
                         else:
-                            regex_pattern = accent_insensitive_regex(v)
-                            clean[k] = {"$regex": regex_pattern, "$options": "i"}
-
+                            clean[k] = {"$regex": accent_insensitive_regex(v), "$options": "i"}
                     elif isinstance(v, dict):
-                        # operadores explícitos ($eq, $gte, etc.)
                         sub = {}
                         for op, val in v.items():
                             if ftype == "date" and isinstance(val, str):
@@ -215,16 +140,12 @@ def sanitize_filter(filter_obj: Any, allowed_fields: Dict[str, str]) -> Any:
                     else:
                         clean[k] = v
         return clean
-
     elif isinstance(filter_obj, list):
         return [sanitize_filter(x, allowed_fields) for x in filter_obj]
-
     else:
         return filter_obj
 
-
-
-def sanitize_sort(sort_obj: Optional[Dict[str, int]], allowed_fields: List[str]) -> Optional[Dict[str, int]]:
+def sanitize_sort(sort_obj: Optional[Dict[str, int]], allowed_fields: Dict[str, str]) -> Optional[Dict[str, int]]:
     if not sort_obj:
         return None
     clean = {}
@@ -233,29 +154,9 @@ def sanitize_sort(sort_obj: Optional[Dict[str, int]], allowed_fields: List[str])
             clean[k] = v
     return clean or None
 
-
 # ---------- LLM Prompting ----------
-
-SYSTEM_PROMPT = (
-    "Eres un generador de consultas ESTRICTAMENTE ESTRUCTURADO para un CRM.\n"
-    "Devuelve SOLO un objeto JSON con este esquema:\n"
-    "{\n"
-    ' "source": "mongo" | "chroma" | "both",\n'
-    ' "mongo": [ { "database": str, "collection": str, "filter": obj, "sort": {campo:1|-1}?, "limit": int? } ],\n'
-    ' "chroma": { "text": str, "limit": int? }?\n'
-    "}\n"
-    "- No expliques nada. Sin comentarios. Sin Markdown. SOLO JSON.\n"
-    "- Si la pregunta requiere datos estructurados (leads, contactos, citas, etc.), usa \"mongo\".\n"
-    "- Si la pregunta es de conocimiento/documentos (políticas, respuestas frecuentes), usa \"chroma\".\n"
-    "- Si aplica ambos, usa \"both\"."
-    "- Si la pregunta es sobre información no estructurada (ej. direcciones, historia, políticas, respuestas frecuentes, documentación, citas, servicios, reservas, informacion de clientes), usa \"chroma\"."
-    "- ejemplo que servicios ha solicitado marcela ortiz utiliza chroma"
-    "- Ejemplo: \"¿Cuál es la dirección de la sede suramericana?\" → { \"source\": \"chroma\", \"chroma\": {\"text\": \"direccion sede suramericana\", \"limit\": 5}, \"mongo\": [] }"
-)
-
-
 def _schema_summary(schema_json: Dict[str, Any]) -> str:
-    lines = ["Bases de datos y colecciones disponibles:"]
+    lines = ["Bases de datos disponibles:"]
     for db_name, collections in schema_json.items():
         if not isinstance(collections, dict):
             continue
@@ -263,39 +164,41 @@ def _schema_summary(schema_json: Dict[str, Any]) -> str:
         for col_name, spec in collections.items():
             fields = spec.get("fields") or []
             fields_preview = ", ".join(map(str, fields[:12]))
-            lines.append(f" • {col_name} (campos: {fields_preview}{' ...' if len(fields)>12 else ''})")
+            lines.append(f"  • {col_name} (campos: {fields_preview}{' ...' if len(fields)>12 else ''})")
     return "\n".join(lines)
 
-
-# ---------- Public API ----------
+SYSTEM_PROMPT = (
+    "Eres un generador de consultas para un CRM/BI.\n"
+    "Devuelve SOLO un JSON con el esquema:\n"
+    "{ 'source': 'mongo'|'chroma'|'both', "
+    "'mongo': [ { 'database': str, 'collection': str, 'operation': 'find'|'count_documents'|'aggregate', "
+    "'filter': obj, 'fields': obj?, 'sort': obj?, 'skip': int?, 'limit': int?, 'pipeline': []? } ], "
+    "'chroma': { 'text': str, 'limit': int? }? }\n"
+    "\n"
+    "- Si piden KPIs, comparaciones de ventas, top-N de sucursales, % de métodos de pago, ranking o dashboards: usa **'chroma'** sobre la colección 'summary'.\n"
+    "- Si piden registros transaccionales detallados (ventas individuales, clientes, inventario): usa 'mongo'.\n"
+    "- Si piden información no estructurada (manuales, políticas, textos largos): usa 'chroma'.\n"
+    "- Si necesitas combinar datos exactos con contexto semántico, usa 'both'.\n"
+    "\n"
+    "Muy importante: cuando la consulta es de tipo BI (KPIs agregados, totales por sucursal, etc.), prioriza siempre 'chroma'.\n"
+)
 
 def query_generator(user_prompt: str) -> dict:
-    """Generate validated queries dict for rag_search.execute_queries()."""
-
     schema_json = load_schema_examples()
     fields_map = allowed_fields_map(schema_json)
-
     client = OpenAI()
     model = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
 
     user_content = (
         _schema_summary(schema_json)
-        + "\n\n"
-        "Instrucciones:\n"
-        "- Escoge correctamente 'source' según la pregunta.\n"
-        "- en 'source' escoge 'chroma' si la pregunta incluye citas, direcciones, servicios.\n"
-        "- Para Mongo, usa solo los nombres de base/colección y campos listados arriba.\n"
-        "- El filtro debe ser un objeto compatible con Mongo (puede incluir $eq, $gte, $in, $regex, $exists).\n"
-        "- Límite por defecto 50 si no se especifica.\n"
-        f"\nPregunta del usuario: {user_prompt}\n"
-        "Responde SOLO con el JSON del esquema indicado.\n"
-        "- Si la pregunta es sobre información no estructurada (ej. direcciones, historia, políticas, respuestas frecuentes, documentación, citas, servicios), usa \"chroma\".\n"
-        "Ejemplo: \"¿Cuál es la dirección de la sede suramericana?\" → { \"source\": \"chroma\", \"chroma\": {\"text\": \"direccion sede suramericana\", \"limit\": 5}, \"mongo\": [] }"
-        "- Utiliza chroma para buscar información no estructurada como citas, direcciones, servicios ejemplo  → { \"source\": \"chroma\", \"chroma\": {\"text\": \"que servicio ha solicitado \"nombre del cliente\"\", \"limit\": 5}, \"mongo\": [] }"
-        "- si no estas seguro de donde buscar utiliza \"chroma\" o \"both\" en 'source' por default"
-        )
-
-    print(f"LLM input:\n{user_content}\n")
+        + "\n\nInstrucciones:\n"
+          "- Genera el mejor 'source'.\n"
+          "- Para Mongo usa solo campos del schema. Usa 'skip/limit' y 'fields' cuando listados.\n"
+          "- Para BI usa 'aggregate' con $match/$group/$project/$sort y paginación con $skip/$limit si hace falta.\n"
+          "- Para Chroma permite 'limit' grande (por ENV) si la consulta lo amerita.\n"
+        f"\nPregunta: {user_prompt}\n"
+        "Responde SOLO con el JSON."
+    )
 
     try:
         resp = client.chat.completions.create(
@@ -309,55 +212,47 @@ def query_generator(user_prompt: str) -> dict:
         )
         raw = resp.choices[0].message.content
     except Exception as e:
-        # Hard fallback: no queries
-        return {
-            "source": "mongo",
-            "mongo": [],
-            "chroma": None,
-            "error": f"LLM error: {e}"
-        }
+        return {"source": "chroma", "mongo": [], "chroma": {"text": user_prompt, "limit": DEFAULT_CHROMA_K}, "error": f"LLM error: {e}"}
 
-    # Parse + validate
     try:
         data = json.loads(raw)
     except Exception as e:
-        return {
-            "source": "mongo",
-            "mongo": [],
-            "chroma": None,
-            "error": f"JSON parse error: {e}",
-            "raw": raw
-        }
+        return {"source": "chroma", "mongo": [], "chroma": {"text": user_prompt, "limit": DEFAULT_CHROMA_K}, "error": f"JSON parse error: {e}", "raw": raw}
 
-    # Pydantic validation
     try:
         bundle = QueriesBundle(**data)
     except ValidationError as e:
-        return {
-            "source": "mongo",
-            "mongo": [],
-            "chroma": None,
-            "error": f"Schema validation error: {e}",
-            "raw": data
-        }
+        return {"source": "chroma", "mongo": [], "chroma": {"text": user_prompt, "limit": DEFAULT_CHROMA_K}, "error": f"Schema validation error: {e}", "raw": data}
 
-    # Sanitize filters/sorts against known fields
+    # Sanitización final (SIN recortes duros)
     sanitized_mongo: List[Dict[str, Any]] = []
+    fields_map_all = allowed_fields_map(schema_json)
     for q in bundle.mongo:
-        allowed_fields = fields_map.get((q.database, q.collection), [])
-        clean_filter = sanitize_filter(q.filter, allowed_fields) if allowed_fields else q.filter
-        clean_sort = sanitize_sort(q.sort, allowed_fields) if allowed_fields else q.sort
-        sanitized_mongo.append({
+        allowed_fields_dict = fields_map_all.get((q.database, q.collection), {})
+        clean_filter = sanitize_filter(q.filter, allowed_fields_dict) if allowed_fields_dict else q.filter
+        clean_sort = sanitize_sort(q.sort, allowed_fields_dict) if allowed_fields_dict else q.sort
+
+        lim = min(max(1, q.limit), MAX_MONGO_LIMIT)
+        skp = max(0, q.skip)
+
+        entry = {
             "database": q.database,
             "collection": q.collection,
-            "filter": clean_filter or {},  # never None
+            "operation": q.operation,
+            "filter": clean_filter or {},
             "sort": clean_sort,
-            "limit": q.limit,
-        })
+            "limit": lim,
+            "skip": skp,
+        }
+        if q.fields: entry["fields"] = q.fields
+        if q.pipeline: entry["pipeline"] = q.pipeline
+        sanitized_mongo.append(entry)
 
-    out = {
-        "source": bundle.source,
-        "mongo": sanitized_mongo,
-        "chroma": bundle.chroma.model_dump() if bundle.chroma else None
-    }
-    return out
+    chroma_query = None
+    if bundle.chroma:
+        chroma_query = {
+            "text": bundle.chroma.text,
+            "limit": min(max(1, bundle.chroma.limit), MAX_CHROMA_LIMIT)
+        }
+
+    return {"source": bundle.source, "mongo": sanitized_mongo, "chroma": chroma_query}

--- a/Backend/app/ai_agent/rag_search.py
+++ b/Backend/app/ai_agent/rag_search.py
@@ -1,14 +1,37 @@
-#rag_search.py
 from app.ai_agent.db_clients import mongo_client, chroma_collections
+import os
+import json
+from typing import Dict, List, Any, Optional
 
-def _mongo_search_single(mongo_entry):
+# ========= Config por ENV =========
+def _get_int_env(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, default))
+    except Exception:
+        return default
+
+MAX_MONGO_LIMIT = _get_int_env("MAX_MONGO_LIMIT", 5000)
+DEFAULT_MONGO_LIMIT = _get_int_env("DEFAULT_MONGO_LIMIT", 500)
+MAX_CHROMA_LIMIT = _get_int_env("MAX_CHROMA_LIMIT", 2000)
+DEFAULT_CHROMA_K = _get_int_env("DEFAULT_CHROMA_K", 100)
+CHROMA_MAX_DOC_LENGTH = _get_int_env("CHROMA_MAX_DOC_LENGTH", 800)   # truncado amable
+AGG_SHOW_LIMIT = _get_int_env("AGG_SHOW_LIMIT", 200)                 # docs a devolver en respuesta
+
+def _mongo_search_single_optimized(mongo_entry: Dict[str, Any]) -> List[Dict[str, Any]]:
     results = []
     db_name = mongo_entry.get("database")
     coll_name = mongo_entry.get("collection")
+    operation = mongo_entry.get("operation", "find")  # find | count_documents | aggregate
     filt = mongo_entry.get("filter", {}) or {}
-    sort = mongo_entry.get("sort") or None
-    limit = mongo_entry.get("limit") or None  # puede ser None
-    do_count = mongo_entry.get("count", False)
+    sort = mongo_entry.get("sort")
+    limit = mongo_entry.get("limit", DEFAULT_MONGO_LIMIT)
+    skip = mongo_entry.get("skip", 0)
+    fields = mongo_entry.get("fields")
+    pipeline = mongo_entry.get("pipeline", [])
+
+    # compat legado
+    if mongo_entry.get("count", False):
+        operation = "count_documents"
 
     if not db_name:
         return results
@@ -17,51 +40,147 @@ def _mongo_search_single(mongo_entry):
     if coll_name:
         try:
             coll = db[coll_name]
-            if do_count:
-                # 👇 modo conteo
+            result_key = f"{db_name}.{coll_name}"
+
+            if operation == "count_documents":
                 count = coll.count_documents(filt)
-                results.append({f"{db_name}.{coll_name}": {"count": count}})
-            else:
-                cursor = coll.find(filt, {"_id": 0})
+                results.append({
+                    result_key: {"operation": "count", "count": count, "filter_applied": filt}
+                })
+
+            elif operation == "aggregate":
+                pipe = list(pipeline) if pipeline else [{"$match": filt}]
+                # Paginación opcional si no viene en pipeline
+                has_limit = any("$limit" in p for p in pipe)
+                has_skip = any("$skip" in p for p in pipe)
+                if not has_skip and skip:
+                    pipe.append({"$skip": skip})
+                if not has_limit and limit:
+                    pipe.append({"$limit": min(limit, MAX_MONGO_LIMIT)})
+                agg_results = list(coll.aggregate(pipe, allowDiskUse=True))
+
+                # Mostrar hasta AGG_SHOW_LIMIT para no rebosar respuesta, pero conservar totales
+                limited_results = agg_results[:AGG_SHOW_LIMIT]
+                results.append({
+                    result_key: {
+                        "operation": "aggregate",
+                        "results": limited_results,
+                        "total_found": len(agg_results),
+                        "showing": len(limited_results),
+                        "page": {"skip": skip, "limit": limit}
+                    }
+                })
+
+            else:  # find
+                projection = {"_id": 0}
+                if fields:
+                    projection.update(fields)
+                cur = coll.find(filt, projection)
                 if sort:
-                    cursor = cursor.sort(list(sort.items()))
-                if limit:
-                    cursor = cursor.limit(limit)
-                docs = list(cursor)
-                results.append({f"{db_name}.{coll_name}": docs})
+                    cur = cur.sort(list(sort.items()))
+                if skip:
+                    cur = cur.skip(skip)
+                cur = cur.limit(min(limit, MAX_MONGO_LIMIT))
+                docs = list(cur)
+                results.append({
+                    result_key: {
+                        "operation": "find",
+                        "documents": docs,
+                        "count": len(docs),
+                        "page": {"skip": skip, "limit": limit}
+                    }
+                })
+
         except Exception as e:
-            results.append({f"{db_name}.{coll_name}": {"error": str(e)}})
+            results.append({f"{db_name}.{coll_name}": {"operation": operation, "error": str(e), "filter": filt}})
     else:
         try:
             for cname in db.list_collection_names():
                 try:
                     coll = db[cname]
-                    if do_count:
+                    result_key = f"{db_name}.{cname}"
+                    if operation == "count_documents":
                         count = coll.count_documents(filt)
-                        results.append({f"{db_name}.{cname}": {"count": count}})
+                        results.append({result_key: {"operation": "count", "count": count}})
                     else:
-                        cursor = coll.find(filt, {"_id": 0})
-                        if sort:
-                            cursor = cursor.sort(list(sort.items()))
-                        if limit:
-                            cursor = cursor.limit(limit)
-                        docs = list(cursor)
-                        results.append({f"{db_name}.{cname}": docs})
+                        cur = coll.find(filt, {"_id": 0}).limit(50)  # por colección
+                        docs = list(cur)
+                        results.append({result_key: {"operation": "find", "documents": docs, "count": len(docs)}})
                 except Exception as e:
-                    results.append({f"{db_name}.{cname}": {"error": str(e)}})
+                    results.append({result_key: {"error": str(e)}})
         except Exception as e:
             results.append({f"{db_name}": {"error": str(e)}})
     return results
 
+def _process_chroma_results(raw_results: Dict, collection_name: str) -> Dict[str, Any]:
+    if not raw_results.get("documents") or not raw_results["documents"][0]:
+        return {"documents": [], "count": 0}
 
-def execute_queries(queries: dict) -> dict:
-    """
-    Ejecuta queries con enrutamiento híbrido:
-    - Si source = mongo → primero Mongo, si vacío y hay chroma, entonces fallback a Chroma.
-    - Si source = chroma → busca en todas las colecciones de Chroma.
-    - Si source = both → primero Mongo, si vacío entonces busca en Chroma.
-    """
-    out = {"chosen_source": None, "mongo": {}, "chroma": None}
+    documents = raw_results["documents"][0]
+    metadatas = raw_results.get("metadatas", [{}])[0] if raw_results.get("metadatas") else [{}] * len(documents)
+    distances = raw_results.get("distances", [{}])[0] if raw_results.get("distances") else [0] * len(documents)
+
+    processed = []
+    for i, doc in enumerate(documents):
+        txt = doc[:CHROMA_MAX_DOC_LENGTH] + ("..." if len(doc) > CHROMA_MAX_DOC_LENGTH else "")
+        processed.append({
+            "content": txt,
+            "metadata": metadatas[i] if i < len(metadatas) else {},
+            "similarity": 1 - distances[i] if i < len(distances) else 0,
+            "collection": collection_name
+        })
+    return {"documents": processed, "count": len(processed), "collection": collection_name}
+
+def _chroma_search_optimized(chroma_query: Dict[str, Any]) -> Dict[str, Any]:
+    if not chroma_query or not chroma_query.get("text"):
+        return {}
+    text = chroma_query["text"]
+    limit = min(max(1, chroma_query.get("limit", DEFAULT_CHROMA_K)), MAX_CHROMA_LIMIT)
+
+    chroma_results = {}
+    for name, collection in chroma_collections.items():
+        try:
+            res = collection.query(query_texts=[text], n_results=limit)
+            chroma_results[name] = _process_chroma_results(res, name)
+        except Exception as e:
+            chroma_results[name] = {"error": str(e)}
+    return chroma_results
+
+def _format_results_summary(results: Dict[str, Any], source: str) -> str:
+    if source == "mongo":
+        parts = []
+        for key, data in results.items():
+            if isinstance(data, dict):
+                if data.get("operation") == "count":
+                    parts.append(f"📊 {key}: {data.get('count', 0)} registros")
+                elif data.get("operation") == "aggregate":
+                    parts.append(f"📈 {key}: {data.get('total_found', 0)} resultados (mostrando {data.get('showing', 0)})")
+                elif data.get("operation") == "find":
+                    parts.append(f"📋 {key}: {data.get('count', 0)} documentos")
+                elif "error" in data:
+                    parts.append(f"❌ {key}: Error - {data['error']}")
+        return "\n".join(parts)
+    elif source == "chroma":
+        parts = []
+        for collection, data in results.items():
+            if isinstance(data, dict) and "documents" in data:
+                parts.append(f"🔍 {collection}: {data.get('count', 0)} documentos relevantes")
+        return "\n".join(parts)
+    return "Sin resultados"
+
+def _has_meaningful_results(mongo_results: Dict[str, Any]) -> bool:
+    if not mongo_results:
+        return False
+    for _, data in mongo_results.items():
+        if not isinstance(data, dict): 
+            continue
+        if data.get("count", 0) > 0: return True
+        if data.get("documents"): return True
+        if data.get("results"): return True
+    return False
+
+def execute_queries_optimized(queries: dict) -> dict:
+    out = {"chosen_source": None, "mongo": {}, "chroma": None, "summary": "", "optimized": True}
 
     source = queries.get("source", "mongo")
     mongo_queries = queries.get("mongo", []) or []
@@ -70,76 +189,49 @@ def execute_queries(queries: dict) -> dict:
     mongo_results = {}
     chroma_results = {}
 
-    # --- Ejecutar Mongo si aplica ---
     if source in ["mongo", "both"]:
         for m in mongo_queries:
-            if not m:
+            if not m: 
                 continue
-            items = _mongo_search_single(m)
+            items = _mongo_search_single_optimized(m)
             for it in items:
                 mongo_results.update(it)
 
-    # --- Caso solo Mongo con fallback a Chroma ---
     if source == "mongo":
         out["chosen_source"] = "mongo"
         out["mongo"] = mongo_results
-
-        if not any(mongo_results.values()) and chroma_query and chroma_query.get("text"):
-            for name, collection in chroma_collections.items():
-                try:
-                    res = collection.query(
-                        query_texts=[chroma_query["text"]],
-                        n_results=chroma_query.get("limit", 5)
-                    )
-                    chroma_results[name] = res.get("results", res)
-                except Exception as e:
-                    chroma_results[name] = {"error": str(e)}
-
+        out["summary"] = _format_results_summary(mongo_results, "mongo")
+        if not _has_meaningful_results(mongo_results) and chroma_query:
+            chroma_results = _chroma_search_optimized(chroma_query)
             out["chosen_source"] = "chroma"
             out["chroma"] = chroma_results
-
+            out["summary"] = _format_results_summary(chroma_results, "chroma")
         return out
 
-    # --- Caso solo Chroma ---
     if source == "chroma":
-        if chroma_query and chroma_query.get("text"):
-            for name, collection in chroma_collections.items():
-                try:
-                    res = collection.query(
-                        query_texts=[chroma_query["text"]],
-                        n_results=chroma_query.get("limit", 5)
-                    )
-                    chroma_results[name] = res.get("results", res)
-                except Exception as e:
-                    chroma_results[name] = {"error": str(e)}
-
+        chroma_results = _chroma_search_optimized(chroma_query)
         out["chosen_source"] = "chroma"
         out["chroma"] = chroma_results
+        out["summary"] = _format_results_summary(chroma_results, "chroma")
         return out
 
-    # --- Caso BOTH ---
     if source == "both":
-        if any(mongo_results.values()):
+        if _has_meaningful_results(mongo_results):
             out["chosen_source"] = "mongo"
             out["mongo"] = mongo_results
+            out["summary"] = _format_results_summary(mongo_results, "mongo")
         else:
-            if chroma_query and chroma_query.get("text"):
-                for name, collection in chroma_collections.items():
-                    try:
-                        res = collection.query(
-                            query_texts=[chroma_query["text"]],
-                            n_results=chroma_query.get("limit", 5)
-                        )
-                        chroma_results[name] = res.get("results", res)
-                    except Exception as e:
-                        chroma_results[name] = {"error": str(e)}
-
+            chroma_results = _chroma_search_optimized(chroma_query)
             out["chosen_source"] = "chroma" if chroma_results else "none"
             out["chroma"] = chroma_results
+            out["summary"] = _format_results_summary(chroma_results, "chroma")
         return out
 
-    # --- Si no aplica nada ---
     out["chosen_source"] = "none"
-    out["mongo"] = mongo_results
-    out["chroma"] = chroma_results
+    out["summary"] = "No se encontraron resultados"
     return out
+
+# Wrapper compat
+def execute_queries(queries: dict) -> dict:
+    return execute_queries_optimized(queries)
+

--- a/Backend/app/ai_agent/schema.json
+++ b/Backend/app/ai_agent/schema.json
@@ -4,7 +4,7 @@
       "fields": ["type", "message", "created_at", "metadata", "status"]
     },
     "community": {
-      "fields": ["community_id", "created_at", "description", "members", "created_at", "title"]
+      "fields": ["community_id", "created_at", "description", "members", "title"]
     },
     "contacts": {
       "fields": ["contact_id", "name", "email", "phone", "created_at", "company"]
@@ -25,12 +25,26 @@
         {"status": "string"},
         {"registration_date": "date"}
       ]
-},
+    },
     "message": {
       "fields": ["message_id", "sender_id", "receiver_id", "content", "created_at"]
     },
     "users": {
       "fields": ["user_id", "full_name", "email", "role", "status", "created_at"]
+    },
+    "sales": {
+      "fields": [
+        {"sale_id": "string"}, 
+        {"identificador": "number"},
+        {"fecha_pago": "date"},
+        {"local": "string"},
+        {"nombre_cliente": "string"},
+        {"email_cliente": "string"},
+        {"telefono_cliente": "string"},
+        {"monto": "number"},
+        {"descuento": "string"},
+        {"usuario_ultima_modificacion": "string"}
+      ]
     }
   },
   "DatabaseInvetary": {
@@ -45,5 +59,3 @@
     }
   }
 }
-
-


### PR DESCRIPTION
#query_generator_pydantic.py
Key changes: I've raised the default limits, added skip, removed "min(...,3/5)" truncations, and allowed ENV-configurable caps.

#Rag_search.py 

Key changes: skip pagination, ENV-configurable limits for Mongo/Chroma, aggregate without truncating (with AGG_SHOW_LIMIT configurable for response), and no min(...,3/5)
If execute_queries() returns mongo.operation == "aggregate", ask the model for a summary of KPIs (trend, top, %dif. if there are two periods) without inventing numbers, just with the returned data.

